### PR TITLE
Add missing @class doc entries for moonwave extractor

### DIFF
--- a/src/BaseCastSerial.luau
+++ b/src/BaseCastSerial.luau
@@ -15,6 +15,12 @@ local Motor6DCache = require(FastCast2:WaitForChild("Motor6DCache"))
 
 local EnumCastTypes = FastCastEnums.CastType
 
+--[=[
+	@class BaseCast
+
+	BaseCast is the underlying class that manages cast simulation, lifecycle, and movement modes.
+	It is used internally by FastCastSerial and FastCastParallel.
+]=]
 local BaseCast = {}
 BaseCast.__index = BaseCast
 BaseCast.__type = "BaseCast"

--- a/src/init.luau
+++ b/src/init.luau
@@ -48,12 +48,6 @@
 
 
 
---[=[
-	@class FastCastParallel
-
-	FastCastParallel is the root class of the module and offers the surface level methods required to make it work. This is the object returned from `require(FastCastParallel)`.
-]=]
-
 -- Services
 
 --local HTTPService = game:GetService("HttpService")
@@ -84,7 +78,12 @@ local VALID_EVENTS = {
 	["CanPierce"] = true
 }
 
--- FastCast
+--[=[
+	@class FastCast
+
+	FastCast provides static utility methods for manipulating active casts (velocity, position, acceleration)
+	and serves as the module root for constructing new Serial and Parallel casters.
+]=]
 
 local FastCast = {}
 FastCast.HighFidelityBehavior = {
@@ -97,7 +96,17 @@ FastCast.CastType = {
 	Blockcast = 2,
 	Spherecast = 3
 }
+--[=[
+	@class FastCastSerial
+
+	FastCastSerial is the serial caster class that runs all cast simulations on the main thread.
+]=]
 local FastCastSerial = {}
+--[=[
+	@class FastCastParallel
+
+	FastCastParallel is the parallel caster class that runs cast simulations on separate worker VMs.
+]=]
 local FastCastParallel = {}
 
 --[[


### PR DESCRIPTION
BaseCast, FastCast, FastCastSerial now have @class doc entries so moonwave's @within references resolve correctly.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal documentation with improved type annotations and class descriptions for better code clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/weenachuangkud/FastCast2/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->