### PR TITLE
Fixed FastCast2 — Hit Event Not Called in Live Server

### DIFF
--- a/src/BaseCastParallel.luau
+++ b/src/BaseCastParallel.luau
@@ -64,7 +64,16 @@ local function TerminateCast(cast: any, castTerminatingFunction: TypeDef.OnCastT
 	end
 end
 
+local BaseCastInitialized = false
+local BaseCastInstance = nil
 function BaseCast.Init(BindableOutput: BindableEvent, Data: any)
+
+	if BaseCastInitialized then
+        warn("[FastCast2] BaseCast already initialized in this Actor. Skipping.")
+        return BaseCastInstance
+    end
+    BaseCastInitialized = true
+	
 	local self = setmetatable({}, BaseCast)
 	Actor = BindableOutput.Parent
 	self.Actives = {}
@@ -144,6 +153,7 @@ function BaseCast.Init(BindableOutput: BindableEvent, Data: any)
 
 	ParallelSimulation.Start()
 
+	BaseCastInstance = self
 	return self
 end
 

--- a/src/ParallelSimulation.luau
+++ b/src/ParallelSimulation.luau
@@ -450,6 +450,12 @@ local ParallelSimulation = {}
 ParallelSimulation.Connection = nil :: RBXScriptConnection?
 
 function ParallelSimulation.Init(baseCastRef: any)
+
+	if ActivesRef ~= nil then
+        warn("[FastCast2] ParallelSimulation already initialized. Skipping.")
+        return
+    end
+
 	BaseCastRef = baseCastRef
 	ActivesRef = baseCastRef.Actives
 end


### PR DESCRIPTION
# FastCast2 — Hit Event Not Called in Live Server

## Symptoms

- **Solo Test / Studio**: Works normally.
- **Team Test / Live Server**: `Hit` callback is not called, and the cast fails to finish/terminate.
- **Output**: Still displays `"Hit was successful. Terminating."`

## Root Cause

`BaseCast.Init()` is being called multiple times within the same Actor (indicated by `► Already started (x4)` in the Output).

Every time `Init` is repeatedly called, it instantiates a new `self.Actives = {}` and passes it to `ParallelSimulation.Init(self)`. This overwrites `ActivesRef` to point to an empty table, while the actual active casts are left stranded in the old table.

```lua
-- FireQueuedEvents in ParallelSimulation.lua
local cast = ActivesRef[castID]  -- ← nil because ActivesRef was overwritten
if not cast then
    continue  -- ← Hit / CastTerminating are completely skipped
end
```

Because `FireQueuedVisualizes` lacks this guard clause, it still prints `"Hit was successful."` as usual, misleading you into thinking the hit function executed successfully.

## Fix

### 1. `BaseCastParallel.lua`

Add these 2 lines at the very top of the file, and implement a guard clause inside `BaseCast.Init()`:

```lua
local BaseCastInitialized = false
local BaseCastInstance = nil

function BaseCast.Init(BindableOutput: BindableEvent, Data: any)
    if BaseCastInitialized then
        warn("[FastCast2] BaseCast already initialized in this Actor. Skipping.")
        return BaseCastInstance
    end
    BaseCastInitialized = true

    -- ... original code ...

    BaseCastInstance = self
    return self
end
```

### 2. `ParallelSimulation.lua`

Add a guard clause inside `ParallelSimulation.Init()`:

```lua
function ParallelSimulation.Init(baseCastRef: any)
    if ActivesRef ~= nil then
        warn("[FastCast2] ParallelSimulation already initialized. Skipping.")
        return
    end
    BaseCastRef = baseCastRef
    ActivesRef = baseCastRef.Actives
end
```

FastCast2.rbxm
[FastCast2.zip](https://github.com/user-attachments/files/28508312/FastCast2.zip)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented initialization validation checks in parallel casting and simulation modules to prevent duplicate initialization attempts. The system now returns the previously initialized instance if reinitialization is attempted, ensuring stable operation and preventing state corruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->