### PR TITLE
Update FastCast2 method calls to use colon syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,22 +311,22 @@ Modify active casts at runtime using the static `FastCast` methods:
 
 ```lua
 -- Read state
-local pos = FastCast2.GetPositionCast(cast)
-local vel = FastCast2.GetVelocityCast(cast)
-local accel = FastCast2.GetAccelerationCast(cast)
+local pos = FastCast2:GetPositionCast(cast)
+local vel = FastCast2:GetVelocityCast(cast)
+local accel = FastCast2:GetAccelerationCast(cast)
 
 -- Modify state (automatically rebases trajectory)
-FastCast2.SetPositionCast(cast, Vector3.new(0, 50, 0))
-FastCast2.SetVelocityCast(cast, Vector3.new(0, 100, 0))
-FastCast2.SetAccelerationCast(cast, Vector3.new(0, -workspace.Gravity, 0))
+FastCast2:SetPositionCast(cast, Vector3.new(0, 50, 0))
+FastCast2:SetVelocityCast(cast, Vector3.new(0, 100, 0))
+FastCast2:SetAccelerationCast(cast, Vector3.new(0, -workspace.Gravity, 0))
 
 -- Relative changes
-FastCast2.AddPositionCast(cast, Vector3.new(0, 10, 0))
-FastCast2.AddVelocityCast(cast, Vector3.new(0, 20, 0))
-FastCast2.AddAccelerationCast(cast, Vector3.new(0, -50, 0))
+FastCast2:AddPositionCast(cast, Vector3.new(0, 10, 0))
+FastCast2:AddVelocityCast(cast, Vector3.new(0, 20, 0))
+FastCast2:AddAccelerationCast(cast, Vector3.new(0, -50, 0))
 
 -- Terminate a cast early (fires CastTerminating and cleans up)
-FastCast2.TerminateCast(cast)
+FastCast2:TerminateCast(cast)
 ```
 
 > **Tip**: In parallel mode, call `Caster:SyncChangesToCast(cast)` after modifying to push changes into the worker VM.

--- a/README.th.md
+++ b/README.th.md
@@ -309,22 +309,22 @@ Caster:SetMovementModeEnabled(true, "BulkMoveTo") -- สลับกลับ
 
 ```lua
 -- อ่านสถานะ
-local pos = FastCast2.GetPositionCast(cast)
-local vel = FastCast2.GetVelocityCast(cast)
-local accel = FastCast2.GetAccelerationCast(cast)
+local pos = FastCast2:GetPositionCast(cast)
+local vel = FastCast2:GetVelocityCast(cast)
+local accel = FastCast2:GetAccelerationCast(cast)
 
 -- ปรับเปลี่ยนสถานะ (โดยอัตโนมัติจะปรับเส้นทางใหม่)
-FastCast2.SetPositionCast(cast, Vector3.new(0, 50, 0))
-FastCast2.SetVelocityCast(cast, Vector3.new(0, 100, 0))
-FastCast2.SetAccelerationCast(cast, Vector3.new(0, -workspace.Gravity, 0))
+FastCast2:SetPositionCast(cast, Vector3.new(0, 50, 0))
+FastCast2:SetVelocityCast(cast, Vector3.new(0, 100, 0))
+FastCast2:SetAccelerationCast(cast, Vector3.new(0, -workspace.Gravity, 0))
 
 -- การเปลี่ยนแปลงสัมพัทธ์
-FastCast2.AddPositionCast(cast, Vector3.new(0, 10, 0))
-FastCast2.AddVelocityCast(cast, Vector3.new(0, 20, 0))
-FastCast2.AddAccelerationCast(cast, Vector3.new(0, -50, 0))
+FastCast2:AddPositionCast(cast, Vector3.new(0, 10, 0))
+FastCast2:AddVelocityCast(cast, Vector3.new(0, 20, 0))
+FastCast2:AddAccelerationCast(cast, Vector3.new(0, -50, 0))
 
 -- สิ้นสุดแคสต์ก่อนเวลาอันควร (ไฟร์ CastTerminating และทำความสะอาด)
-FastCast2.TerminateCast(cast)
+FastCast2:TerminateCast(cast)
 ```
 
 > **เคล็ดลับ**: ในโหมดขนาน โทร `Caster:SyncChangesToCast(cast)` หลังจากปรับเปลี่ยนเพื่อดันการเปลี่ยนแปลงเข้าสู่เวิร์กเกอร์ VM

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -113,25 +113,25 @@ Caster:SetObjectCacheEnabled(enabled, Template?, CacheSize?, CacheHolder?) → (
 
 --// Cast Manipulation  (use FastCast static methods)
 
-FastCast.GetPositionCast(cast) → Vector3
-FastCast.GetVelocityCast(cast) → Vector3
-FastCast.GetAccelerationCast(cast) → Vector3
+FastCast:GetPositionCast(cast) → Vector3
+FastCast:GetVelocityCast(cast) → Vector3
+FastCast:GetAccelerationCast(cast) → Vector3
 
-FastCast.SetVelocityCast(cast, velocity) → ()
-FastCast.SetAccelerationCast(cast, acceleration) → ()
-FastCast.SetPositionCast(cast, position) → ()
+FastCast:SetVelocityCast(cast, velocity) → ()
+FastCast:SetAccelerationCast(cast, acceleration) → ()
+FastCast:SetPositionCast(cast, position) → ()
 
-FastCast.AddPositionCast(cast, position) → ()
-FastCast.AddVelocityCast(cast, velocity) → ()
-FastCast.AddAccelerationCast(cast, acceleration) → ()
+FastCast:AddPositionCast(cast, position) → ()
+FastCast:AddVelocityCast(cast, velocity) → ()
+FastCast:AddAccelerationCast(cast, acceleration) → ()
 
 -- ⚠ After any Set/Add, sync changes to push state to the worker VM:
 Caster:SyncChangesToCast(cast) → ()
 
-FastCast.TerminateCast(cast) → ()
+FastCast:TerminateCast(cast) → ()
 -- TerminateCast fires CastTerminating, returns cosmetic to cache, and unregisters the cast.
 -- Call from Hit/Pierced callback to stop a cast early:
--- caster.Hit = function(cast) FastCast.TerminateCast(cast) end
+-- caster.Hit = function(cast) FastCast:TerminateCast(cast) end
 
 
 --// Lifecycle


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Cast manipulation" code example with improved syntax and clearer section organization, including dedicated areas for reading state, modifying state, and terminating casts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->