### PR TITLE
fix: resolve broken links in moonwave build

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Unofficial continuation of FastCast for Roblox
 ![GitHub release](https://img.shields.io/github/v/release/weenachuangkud/FastCast2?style=for-the-badge)
 [![DevForum](https://img.shields.io/badge/discuss-DevForum-orange?style=for-the-badge&logo=roblox)](https://devforum.roblox.com/t/fastcast2-an-improved-version-of-fastcast-with-parallel-scripting-more-extensions-and-statically-typed/4093890)
 
-[English](README.md) |
-[ภาษาไทย](README.th.md)
+[English](https://github.com/weenachuangkud/FastCast2/blob/main/README.md) |
+[ภาษาไทย](https://github.com/weenachuangkud/FastCast2/blob/main/README.th.md)
 
 </div>
 

--- a/README.th.md
+++ b/README.th.md
@@ -23,8 +23,8 @@
 ![GitHub release](https://img.shields.io/github/v/release/weenachuangkud/FastCast2?style=for-the-badge)
 [![DevForum](https://img.shields.io/badge/discuss-DevForum-orange?style=for-the-badge&logo=roblox)](https://devforum.roblox.com/t/fastcast2-an-improved-version-of-fastcast-with-parallel-scripting-more-extensions-and-statically-typed/4093890)
 
-[English](README.md) |
-[ภาษาไทย](README.th.md)
+[English](https://github.com/weenachuangkud/FastCast2/blob/main/README.md) |
+[ภาษาไทย](https://github.com/weenachuangkud/FastCast2/blob/main/README.th.md)
 
 </div>
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -23,8 +23,8 @@ Unofficial continuation of FastCast for Roblox
 ![GitHub release](https://img.shields.io/github/v/release/weenachuangkud/FastCast2?style=for-the-badge)
 [![DevForum](https://img.shields.io/badge/discuss-DevForum-orange?style=for-the-badge&logo=roblox)](https://devforum.roblox.com/t/fastcast2-an-improved-version-of-fastcast-with-parallel-scripting-more-extensions-and-statically-typed/4093890)
 
-[English](README.md) |
-[ภาษาไทย](README.th.md)
+[English](https://github.com/weenachuangkud/FastCast2/blob/main/README.md) |
+[ภาษาไทย](https://github.com/weenachuangkud/FastCast2/blob/main/README.th.md)
 
 </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated language selector links in documentation to reference GitHub URLs directly instead of relative paths, ensuring reliable and consistent navigation between English and Thai language versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->