### PR TITLE
Update FastCast method syntax from dot to colon (DOCS)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -140,22 +140,22 @@ caster:SpherecastFire(Vector3.new(0, 5, 0), 3, Vector3.new(0, 0, -1), 500, behav
 
 ```lua
 -- Getters
-FastCast.GetPositionCast(cast) → Vector3
-FastCast.GetVelocityCast(cast) → Vector3
-FastCast.GetAccelerationCast(cast) → Vector3
+FastCast:GetPositionCast(cast) → Vector3
+FastCast:GetVelocityCast(cast) → Vector3
+FastCast:GetAccelerationCast(cast) → Vector3
 
 -- Setters (modifies trajectory, triggers CancelHighResCast)
-FastCast.SetVelocityCast(cast, velocity) → ()
-FastCast.SetAccelerationCast(cast, acceleration) → ()
-FastCast.SetPositionCast(cast, position) → ()
+FastCast:SetVelocityCast(cast, velocity) → ()
+FastCast:SetAccelerationCast(cast, acceleration) → ()
+FastCast:SetPositionCast(cast, position) → ()
 
 -- Adders (relative modification)
-FastCast.AddPositionCast(cast, position) → ()
-FastCast.AddVelocityCast(cast, velocity) → ()
-FastCast.AddAccelerationCast(cast, acceleration) → ()
+FastCast:AddPositionCast(cast, position) → ()
+FastCast:AddVelocityCast(cast, velocity) → ()
+FastCast:AddAccelerationCast(cast, acceleration) → ()
 
 -- Termination
-FastCast.TerminateCast(cast) → ()
+FastCast:TerminateCast(cast) → ()
 ```
 
 In **parallel mode**, call `caster:SyncChangesToCast(cast)` after any Set/Add to push state to the worker VM.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API reference documentation for cast manipulation methods with corrected method syntax and consistent return-type notation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->