### PR TITLE
Fix: Make default.project.json works with wally

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -1,12 +1,9 @@
 {
 	"name": "FastCast2",
 	"tree": {
-		"$className": "DataModel",
-		"ReplicatedStorage": {
-			"FastCast2": {
-				"$path": "src"
-			},
-			"$ignoreUnknownInstances": true
+		"$path": "src/Packages",
+		"FastCast2": {
+			"$path": "src"
 		}
 	}
 }

--- a/default.project.json
+++ b/default.project.json
@@ -1,9 +1,6 @@
 {
 	"name": "FastCast2",
 	"tree": {
-		"$path": "src/Packages",
-		"FastCast2": {
-			"$path": "src"
-		}
+		"$path": "src"
 	}
 }


### PR DESCRIPTION
Thanks [nerd0ne](https://github.com/nerd0ne) for the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated project path mappings to use the simplified package structure.
  * Removed legacy instance mapping and unknown-instance handling settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->